### PR TITLE
neighbors param is now removed in skimage. use connectivity instead

### DIFF
--- a/HD_BET/utils.py
+++ b/HD_BET/utils.py
@@ -71,7 +71,7 @@ def postprocess_prediction(seg):
     # basically look for connected components and choose the largest one, delete everything else
     print("running postprocessing... ")
     mask = seg != 0
-    lbls = label(mask, 8)
+    lbls = label(mask, connectivity=mask.ndim)
     lbls_sizes = [np.sum(lbls == i) for i in np.unique(lbls)]
     largest_region = np.argmax(lbls_sizes[1:]) + 1
     seg[lbls != largest_region] = 0


### PR DESCRIPTION
The `neighbors` parameter in the `skimage.morphology.label` was deprecated and removed in scikit-image v0.18. Scikit-image recommends the use of the `connectivity` parameter instead. A `neighbors` value of 8 corresponds to a `connectivity` value equal to the dimension of the input image.