### PR TITLE
Make hd-bet executable

### DIFF
--- a/HD_BET/hd-bet
+++ b/HD_BET/hd-bet
@@ -1,3 +1,5 @@
+#!/usr/bin/env python
+
 import os
 from HD_BET.run import run_hd_bet
 from HD_BET.utils import maybe_mkdir_p, subfiles


### PR DESCRIPTION
Hi,

Without the following changes, `hd-bet` cannot be run as https://github.com/MIC-DKFZ/HD-BET#how-to-use-it

* insert shebang line for python
* set exec permission of hd-bet

I am working on a CentOS 7 Linux computer. Let me know if you have any questions.