### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 numpy>=1.14.5
 torch>=0.4.0
 scikit-image>=0.14.0
-SimpleITK
+SimpleITK==2.0.2
 -e git+https://github.com/MIC-DKFZ/batchgenerators#egg=batchgenerators


### PR DESCRIPTION
To avoid the occasionally occurring error 
'ITK ERROR: ITK only supports orthonormal direction cosines.  No orthonormal definition found!' from happening, please use SimpleITK 2.0.2