### PR TITLE
Resolve SyntaxWarning for use of "is not" with a literal

### DIFF
--- a/HD_BET/config.py
+++ b/HD_BET/config.py
@@ -31,7 +31,7 @@ class BaseConfig(object):
     def __repr__(self):
         res = ""
         for v in vars(self):
-            if not v.startswith("__") and not v.startswith("_") and v is not 'dataset':
+            if not v.startswith("__") and not v.startswith("_") and v != 'dataset':
                 res += (v + ": " + str(self.__getattribute__(v)) + "\n")
         return res
 


### PR DESCRIPTION
Resolves 

`/HD-BET-master/HD_BET/config.py:34: SyntaxWarning:
"is not" with a literal. Did you mean "!="?`

in Python >3.8