### PR TITLE
Correct size comparison, fixes #45 numpy>=1.25 incompatibility

### DIFF
--- a/HD_BET/data_loading.py
+++ b/HD_BET/data_loading.py
@@ -84,7 +84,7 @@ def save_segmentation_nifti(segmentation, dct, out_fname, order=1):
                      bbox[2][0]:bbox[2][1]] = segmentation
     else:
         seg_old_size = segmentation
-    if np.any(np.array(seg_old_size) != np.array(dct['size'])[[2, 1, 0]]):
+    if np.any(np.array(seg_old_size.shape) != np.array(dct['size'])[[2, 1, 0]]):
         seg_old_spacing = resize_segmentation(seg_old_size, np.array(dct['size'])[[2, 1, 0]], order=order)
     else:
         seg_old_spacing = seg_old_size


### PR DESCRIPTION
save_segmentation_nifti was comparing the entire segmentation array to target size. Prior numpy-1.25 this returned always false and a swallowed deprecation warning. Raises an error since numpy-1.25:
	File "HD-BET/HD_BET/data_loading.py", line 87, in save_segmentation_nifti
		if np.any(np.array(seg_old_size) != np.array(dct['size'])[[2, 1, 0]]):
	ValueError: operands could not be broadcast together with shapes (117,171,171) (3,)

fixes #45 by comparing current shape to target shape.