### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-numpy>=1.14.5
+numpy>=1.14.5,<1.25.0
 torch>=0.4.0
 scikit-image>=0.14.0
 SimpleITK>=2.0.2


### PR DESCRIPTION
Define a max version for numpy.

Context: With numpy 1.25.0 hd-bet fails and throws errors.

PS: Oh I just found this thread: https://github.com/MIC-DKFZ/HD-BET/issues/45