### PR TITLE
Option not to apply skull-stripping and uint8 for the brain mask

### DIFF
--- a/HD_BET/data_loading.py
+++ b/HD_BET/data_loading.py
@@ -55,7 +55,7 @@ def load_and_preprocess(mri_file):
     return all_data, properties_dict
 
 
-def save_segmentation_nifti(segmentation, dct, out_fname, order=1):
+def save_segmentation_nifti(segmentation, dct, out_fname, order=1, dtype=np.uint8):
     '''
     segmentation must have the same spacing as the original nifti (for now). segmentation may have been cropped out
     of the original image
@@ -88,7 +88,7 @@ def save_segmentation_nifti(segmentation, dct, out_fname, order=1):
         seg_old_spacing = resize_segmentation(seg_old_size, np.array(dct['size'])[[2, 1, 0]], order=order)
     else:
         seg_old_spacing = seg_old_size
-    seg_resized_itk = sitk.GetImageFromArray(seg_old_spacing.astype(np.int32))
+    seg_resized_itk = sitk.GetImageFromArray(seg_old_spacing.astype(dtype))
     seg_resized_itk.SetSpacing(np.array(dct['spacing'])[[0, 1, 2]])
     seg_resized_itk.SetOrigin(dct['origin'])
     seg_resized_itk.SetDirection(dct['direction'])

--- a/HD_BET/hd-bet
+++ b/HD_BET/hd-bet
@@ -46,6 +46,7 @@ if __name__ == "__main__":
     parser.add_argument('--overwrite_existing', default=1, type=int, required=False, help="set this to 0 if you don't "
                                                                                           "want to overwrite existing "
                                                                                           "predictions")
+    parser.add_argument('-b','--bet', default=1, type=int, required=False, help="set this to 0 if you don't want to save skull-stripped brain")
 
     args = parser.parse_args()
 
@@ -62,6 +63,7 @@ if __name__ == "__main__":
     pp = args.pp
     save_mask = args.save_mask
     overwrite_existing = args.overwrite_existing
+    bet = args.bet
 
     params_file = os.path.join(HD_BET.__path__[0], "model_final.py")
     config_file = os.path.join(HD_BET.__path__[0], "config.py")
@@ -116,6 +118,17 @@ if __name__ == "__main__":
     elif save_mask == 1:
         save_mask = True
     else:
-        raise ValueError("Unknown value for pp: %s. Expected: 0 or 1" % str(pp))
+        raise ValueError("Unknown value for save_mask: %s. Expected: 0 or 1" % str(save_mask))
 
-    run_hd_bet(input_files, output_files, mode, config_file, device, pp, tta, save_mask, overwrite_existing)
+    if bet == 0:
+        if save_mask:
+            bet = False
+        else:
+            print("Save_mask and bet are set to 0. In this case, Bet is set to 1.")
+            bet = True
+    elif bet == 1:
+        bet = True
+    else:
+        raise ValueError("Unknown value for bet: %s. Expected: 0 or 1" % str(pp))
+    
+    run_hd_bet(input_files, output_files, mode, config_file, device, pp, tta, save_mask, overwrite_existing, bet)

--- a/HD_BET/run.py
+++ b/HD_BET/run.py
@@ -20,7 +20,7 @@ def apply_bet(img, bet, out_fname):
 
 
 def run_hd_bet(mri_fnames, output_fnames, mode="accurate", config_file=os.path.join(HD_BET.__path__[0], "config.py"), device=0,
-               postprocess=False, do_tta=True, keep_mask=True, overwrite=True):
+               postprocess=False, do_tta=True, keep_mask=True, overwrite=True, bet=False):
     """
 
     :param mri_fnames: str or list/tuple of str
@@ -108,8 +108,8 @@ def run_hd_bet(mri_fnames, output_fnames, mode="accurate", config_file=os.path.j
 
             print("exporting segmentation...")
             save_segmentation_nifti(seg, data_dict, mask_fname)
-
-            apply_bet(in_fname, mask_fname, out_fname)
+            if bet:
+                apply_bet(in_fname, mask_fname, out_fname)
 
             if not keep_mask:
                 os.remove(mask_fname)


### PR DESCRIPTION
1. Sometimes only the brain mask is needed. To avoid generating the unwanted skull-stripped brain image, an option not to apply skull-stripping was added. 
2. The brain mask is binary, so uint8 would be sufficient.