### PR TITLE
Update run.py

### DIFF
--- a/HD_BET/run.py
+++ b/HD_BET/run.py
@@ -75,7 +75,8 @@ def run_hd_bet(mri_fnames, output_fnames, mode="accurate", config_file=os.path.j
         params.append(torch.load(p, map_location=lambda storage, loc: storage))
 
     for in_fname, out_fname in zip(mri_fnames, output_fnames):
-        mask_fname = out_fname[:-7] + "_mask.nii.gz"
+        # mask_fname = out_fname[:-7] + "_mask.nii.gz" # If user doesn't include '.nii.gz' ext, this will cause issues
+        mask_fname = out_fname.replace('.nii.gz','') + '_mask.nii.gz' # this should work even if out_fname doesn't include .nii.gz ext
         if overwrite or (not (os.path.isfile(mask_fname) and keep_mask) or not os.path.isfile(out_fname)):
             print("File:", in_fname)
             print("preprocessing...")


### PR DESCRIPTION
The current run_hd_bet function has a hard-coded string filter on the output mask name to append _mask.nii.gz to the output mask (line 78: mask_fname = out_fname[:-7] + "_mask.nii.gz"). However, if the user doesn't include the '.nii.gz' extension in the out_fname parameter, this will cause issues. For example, if out_fname is set to 'hd_bet_output', the resulting mask name will be 'hd_bet.nii.gz'.

This update fixes this small bug and should work in both cases (i.e. where a user includes the '.nii.gz' extension, and those when the user doesn't include the '.nii.gz' extension).